### PR TITLE
feat(cicd): GitHub Actions Cloud Run deploy + WIF auth (#20)

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -1,0 +1,78 @@
+name: Backend — Build & Deploy to Cloud Run
+
+on:
+  push:
+    branches: [main]
+    paths: ["backend/**"]
+  workflow_dispatch:
+
+env:
+  PROJECT_ID: ai-director-mvp
+  REGION: us-central1
+  REGISTRY: us-central1-docker.pkg.dev
+  SERVICE: ai-director-api
+  IMAGE: us-central1-docker.pkg.dev/ai-director-mvp/ai-director-docker/api
+  SA_EMAIL: ai-director-backend@ai-director-mvp.iam.gserviceaccount.com
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for Workload Identity Federation
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python + uv
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv and sync deps
+        working-directory: backend
+        run: pip install uv && uv sync
+
+      - name: Authenticate to Google Cloud (Workload Identity Federation)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build and push Docker image
+        working-directory: backend
+        run: |
+          docker build \
+            -t ${{ env.IMAGE }}:${{ github.sha }} \
+            -t ${{ env.IMAGE }}:latest \
+            .
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ${{ env.SERVICE }} \
+            --image ${{ env.IMAGE }}:${{ github.sha }} \
+            --region ${{ env.REGION }} \
+            --platform managed \
+            --allow-unauthenticated \
+            --service-account ${{ env.SA_EMAIL }} \
+            --update-env-vars "MINIMAX_API_KEY=${{ secrets.MINIMAX_API_KEY }},MINIMAX_GROUP_ID=${{ secrets.MINIMAX_GROUP_ID }},ELEVENLABS_API_KEY=${{ secrets.ELEVENLABS_API_KEY }},GCP_PROJECT_ID=${{ env.PROJECT_ID }},GCP_BUCKET_NAME=ai-director-mvp-media,FRONTEND_URL=${{ secrets.FRONTEND_URL }}" \
+            --min-instances 0 \
+            --max-instances 10 \
+            --memory 1Gi \
+            --cpu 1 \
+            --timeout 300 \
+            --project ${{ env.PROJECT_ID }}
+
+      - name: Print deployment URL
+        run: |
+          URL=$(gcloud run services describe ${{ env.SERVICE }} \
+            --region ${{ env.REGION }} --project ${{ env.PROJECT_ID }} \
+            --format 'value(status.url)')
+          echo "✅ Deployed: $URL"

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,9 +11,14 @@ from pydantic import BaseModel
 load_dotenv()
 
 # Initialize Firebase Admin
-_cred_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "./backend-service-account.json")
-_firebase_cred = firebase_admin.credentials.Certificate(_cred_path)
-firebase_admin.initialize_app(_firebase_cred)
+# On Cloud Run, use Application Default Credentials (ADC).
+# Locally, use service account key file via GOOGLE_APPLICATION_CREDENTIALS.
+_cred_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+if _cred_path and os.path.isfile(_cred_path):
+    _firebase_cred = firebase_admin.credentials.Certificate(_cred_path)
+    firebase_admin.initialize_app(_firebase_cred)
+else:
+    firebase_admin.initialize_app()  # ADC on Cloud Run
 
 from middleware.auth import verify_token
 from services import voices as voice_service


### PR DESCRIPTION
## Summary
- GitHub Actions workflow triggers on push to main (backend/** changes)
- Keyless GCP auth via Workload Identity Federation (no long-lived service account keys)
- Build Docker image → push to Artifact Registry → deploy to Cloud Run
- Cloud Run service uses attached service account for ADC (no credential file needed)
- WIF pool and OIDC provider already configured in GCP project ai-director-mvp
- GCP secrets (WIF provider, SA email) already set in GitHub repo

## Remaining GitHub secrets to add manually
| Secret | Value |
|--------|-------|
| MINIMAX_API_KEY | Your MiniMax API key |
| MINIMAX_GROUP_ID | Your MiniMax Group ID |
| ELEVENLABS_API_KEY | Your ElevenLabs API key |
| FRONTEND_URL | Vercel deployment URL (after frontend deploy) |

## Test plan
- [ ] Add API key secrets in GitHub repo settings
- [ ] Merge this PR + push a backend change to trigger workflow
- [ ] Verify Cloud Run deployment succeeds
- [ ] Test live API endpoint with `curl {cloud-run-url}/health`

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)